### PR TITLE
Add 13 fork-verified failed-ICO refund vaults (~57 ETH, 87 addresses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Full list in [`data/protocols.json`](data/protocols.json).
 
 | Date | Protocol | ETH | Addresses | Notes |
 |------|----------|-----|-----------|-------|
+| Jun 11 | Failed-ICO refund vaults (x13) | 57 | 87 | Abyss DAICO, Confideal, Start Mining (STM), I2Presale, Bayesin (BYS), Mahala Coin (MHC), Crowdsale x3, CrowdsaleWatch, SingularDTV Launch, Reservation2, Gateway. Per-user refund of own deposit (failed soft caps / aborted sales). 1-10 ETH BigQuery discovery sweep beyond the existing set; each fork-verified (Foundry mainnet fork, 39/39 tests) + safety-audited; holder lists filtered to self-claimable EOAs (Binance + service/contract addresses excluded). Community PR [@webmixgamer]. |
 | May 2 | Score70 recovery batch | 1,510 | 10,099 | MCDEX Perpetual, Quantfury QDT, Monolith TKN Holder, EKS, TweetMarket, Treasure, Celer EthPool, ETH Staking Rewards, Meme Limited Collections. Dune enumeration + local reth verification; contract-holder rows with reverting withdrawal calls excluded. |
 | Apr 15 | Celer Payment Channels | 151 | 1,551 | Unilateral intendWithdraw → 10k-block window → confirmWithdraw (OSP slice excluded) |
 | Apr 13 | GavCoin | 47 | 115 | 2015 bonding-curve ICO, per-user refund |

--- a/data/balances/abyss_daico_fund_eth_balances.json
+++ b/data/balances/abyss_daico_fund_eth_balances.json
@@ -1,0 +1,110 @@
+{
+  "contract": "0xe4972421f88c1f47986f54cbfd2d1e2e671680ac",
+  "balance_source": "eth",
+  "contract_eth_balance": 9.89995077,
+  "total_eth_in_balances": 9.89995077,
+  "addresses_with_balance": 13,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "The 2018 Abyss (ABYSS) DAICO raised ~803 ETH against an ~11,538 ETH soft cap (~93% short). The crowdsale called enableCrowdsaleRefund(), latching the Fund into state CrowdsaleRefund (==1, on-chain now) with no code path out. refundCrowdsaleContributor() returns each contributor their own contributions[] deposit (zeroed before send). The team withdraw paths need the unreachable TeamWithdraw(2) state and the pooled refundTokenHolder() needs the unreachable Refund(3), so the owner cannot drain. 269 contributors already refunded; the balance reconciles to the wei across the unrefunded contributors.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 6,
+      "total_eth": 8.0618
+    },
+    "0.1-1 ETH": {
+      "count": 7,
+      "total_eth": 1.83815077
+    }
+  },
+  "name": "Abyss DAICO Fund (PollManagedFund)",
+  "claim_flow": "refundCrowdsaleContributor()",
+  "refund_selector": "0xff01ffa8",
+  "balance_selector": "0x42e94c90",
+  "state_checks": [
+    "state() == 1 (FundState.CrowdsaleRefund)"
+  ],
+  "total_addresses_scanned": 13,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x14ff306bc291f53001dbfbc0584cbf117799ff12",
+      "balance_wei": "2800000000000000000",
+      "balance_eth": 2.8
+    },
+    {
+      "rank": 2,
+      "address": "0x8884706b9d6e0b8a59b7b658f9bd1d094c2d5cae",
+      "balance_wei": "1261800000000000000",
+      "balance_eth": 1.2618
+    },
+    {
+      "rank": 3,
+      "address": "0x745c28e5f72700cfea5e91882a83ae928bcc3b99",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 4,
+      "address": "0x921c1caaab432e83f61eebc0855d7c120e95911b",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 5,
+      "address": "0xabeb030b48745fa8c8acac279135851b9649195c",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 6,
+      "address": "0xcbbfda3c747e51babdec86bed0e277fec03f6cca",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 7,
+      "address": "0xac21b53ebec5e67fc7321c25a529c267e86758d8",
+      "balance_wei": "423203524000000000",
+      "balance_eth": 0.42320352
+    },
+    {
+      "rank": 8,
+      "address": "0x845dbb80bd79d1193c4d3f620dcbf937f54b8064",
+      "balance_wei": "381151890000000000",
+      "balance_eth": 0.38115189
+    },
+    {
+      "rank": 9,
+      "address": "0x17b3793de7f8239a7bfc0d2b2047933e8f2b6e3f",
+      "balance_wei": "233795360000000000",
+      "balance_eth": 0.23379536
+    },
+    {
+      "rank": 10,
+      "address": "0x792de3f7a7c4b71ca6786f193a98a1516ba58488",
+      "balance_wei": "200000000000000000",
+      "balance_eth": 0.2
+    },
+    {
+      "rank": 11,
+      "address": "0x8f41122ff5874620141a8952156c9dcd3d0fe930",
+      "balance_wei": "200000000000000000",
+      "balance_eth": 0.2
+    },
+    {
+      "rank": 12,
+      "address": "0xa8a34ca7f1ae812a6a5cb02f90d89f6429b8cca8",
+      "balance_wei": "200000000000000000",
+      "balance_eth": 0.2
+    },
+    {
+      "rank": 13,
+      "address": "0xaa1de66335ed5360b5ed91f6cf8d185d3342511f",
+      "balance_wei": "200000000000000000",
+      "balance_eth": 0.2
+    }
+  ]
+}

--- a/data/balances/bayesin_bys_crowsale_eth_balances.json
+++ b/data/balances/bayesin_bys_crowsale_eth_balances.json
@@ -1,0 +1,63 @@
+{
+  "contract": "0xe8b1b40f2d307bce891833f46eef1f69560e6926",
+  "balance_source": "eth",
+  "contract_eth_balance": 5.4279,
+  "total_eth_in_balances": 5.4279,
+  "addresses_with_balance": 5,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed BYS crowdsale past its deadline (freeCrawDeadline 1536681600, Sep-2018) with the max goal unmet, so safeWithdrawal() (in the !goalReached branch) returns each contributor their own fundBalance[] deposit. The owner payout branch needs goalReached (never), so the stuck ETH is refund-only.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 3.0
+    },
+    "0.1-1 ETH": {
+      "count": 4,
+      "total_eth": 2.4279
+    }
+  },
+  "name": "Bayesin (BYS) CrowSale",
+  "claim_flow": "safeWithdrawal()",
+  "refund_selector": "0xfd6b7ef8",
+  "balance_selector": "0x0ad5a865",
+  "state_checks": [
+    "now >= freeCrawDeadline()",
+    "amountRaised < maxGoal"
+  ],
+  "total_addresses_scanned": 5,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x33a43d70127caae87cc6b14ffb2fda99d2c8299c",
+      "balance_wei": "3000000000000000000",
+      "balance_eth": 3.0
+    },
+    {
+      "rank": 2,
+      "address": "0x6170cf7272d897801fc174529f3c2537c672ee69",
+      "balance_wei": "997900000000000000",
+      "balance_eth": 0.9979
+    },
+    {
+      "rank": 3,
+      "address": "0x15933a3325220068a340a6e8de34ea510e620de3",
+      "balance_wei": "880000000000000000",
+      "balance_eth": 0.88
+    },
+    {
+      "rank": 4,
+      "address": "0x164dd67a6095af86870ceeab541cab140fcb0115",
+      "balance_wei": "450000000000000000",
+      "balance_eth": 0.45
+    },
+    {
+      "rank": 5,
+      "address": "0x1be1807e1e223700d8f6e78079259fca1f7ffdd1",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    }
+  ]
+}

--- a/data/balances/confideal_campaign_eth_balances.json
+++ b/data/balances/confideal_campaign_eth_balances.json
@@ -1,0 +1,56 @@
+{
+  "contract": "0x17681500757628c7aa56d7e6546e119f94dd9479",
+  "balance_source": "eth",
+  "contract_eth_balance": 8.625,
+  "total_eth_in_balances": 8.2,
+  "addresses_with_balance": 4,
+  "coverage_pct": 95.07,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A Dec-2017 Confideal crowdsale (Campaign) that raised 9.6141 ETH against a 1,000 ETH funding threshold, so stage() is permanently Stage.Failure. withdrawRefund() (nonReentrant) returns each contributor their own contributions[] deposit. The beneficiary payout withdrawPayout() needs Stage.Success (unreachable) and reclaimEther() reverts, so funds cannot be drained.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 3,
+      "total_eth": 8.0
+    },
+    "0.1-1 ETH": {
+      "count": 1,
+      "total_eth": 0.2
+    }
+  },
+  "name": "Confideal Campaign",
+  "claim_flow": "withdrawRefund()",
+  "refund_selector": "0x110f8874",
+  "balance_selector": "0x42e94c90",
+  "state_checks": [
+    "stage() == 3 (Stage.Failure)"
+  ],
+  "total_addresses_scanned": 5,
+  "residual_unattributed_eth": 0.425,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0xa0b8b814f2ab93f63a42e37ddcab994b5b21a29b",
+      "balance_wei": "3000000000000000000",
+      "balance_eth": 3.0
+    },
+    {
+      "rank": 2,
+      "address": "0xa64087caef3451e2ef8d96735ba1408e77812033",
+      "balance_wei": "3000000000000000000",
+      "balance_eth": 3.0
+    },
+    {
+      "rank": 3,
+      "address": "0xc4a6c9020257a594565b5325a935215b20eb1357",
+      "balance_wei": "2000000000000000000",
+      "balance_eth": 2.0
+    },
+    {
+      "rank": 4,
+      "address": "0x9a015e1f453ccd7c64518f496ad964e395c60234",
+      "balance_wei": "200000000000000000",
+      "balance_eth": 0.2
+    }
+  ]
+}

--- a/data/balances/crowdsale_4363b5_eth_balances.json
+++ b/data/balances/crowdsale_4363b5_eth_balances.json
@@ -1,0 +1,68 @@
+{
+  "contract": "0x4363b5d64f228c819dc706889b09a0dc76e22fb0",
+  "balance_source": "eth",
+  "contract_eth_balance": 8.476,
+  "total_eth_in_balances": 8.28,
+  "addresses_with_balance": 6,
+  "coverage_pct": 97.69,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed crowdsale (8.476 ETH held vs a 10,000 ETH soft cap, sale ended Dec-2018). saleFailed (now>end && balance<softCap) is satisfied, so releaseEthers() returns each contributor their own etherHoldings[] deposit (read via returnETher(address)). The owner ETH-out safeWithdrawal() needs the soft cap reached (never), so the owner cannot drain.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 3,
+      "total_eth": 5.905
+    },
+    "0.1-1 ETH": {
+      "count": 3,
+      "total_eth": 2.375
+    }
+  },
+  "name": "Crowdsale (0x4363b5)",
+  "claim_flow": "releaseEthers()",
+  "refund_selector": "0x98be7df7",
+  "balance_selector": "0x5986a13d",
+  "state_checks": [
+    "now > end() && balance < softCap() (saleFailed)"
+  ],
+  "total_addresses_scanned": 7,
+  "residual_unattributed_eth": 0.196,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x4397ec886c5db216b82e351911c9e3c2b7f5091e",
+      "balance_wei": "3905000000000000000",
+      "balance_eth": 3.905
+    },
+    {
+      "rank": 2,
+      "address": "0xd33577609f71eeb9e72b8b077590f50f9cbbce0a",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 3,
+      "address": "0xfdd86ee46f5ce82c974090151c60ca2a3311aa71",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 4,
+      "address": "0x71e93604728ef427a2b34439c5f3a406e2f8fb50",
+      "balance_wei": "990000000000000000",
+      "balance_eth": 0.99
+    },
+    {
+      "rank": 5,
+      "address": "0x88dbf765188519dba2fe1e3a0396a6c097fd4fab",
+      "balance_wei": "985000000000000000",
+      "balance_eth": 0.985
+    },
+    {
+      "rank": 6,
+      "address": "0x87af7fa024035df14c940c139b3252bb5a5b3944",
+      "balance_wei": "400000000000000000",
+      "balance_eth": 0.4
+    }
+  ]
+}

--- a/data/balances/crowdsale_c699d9_eth_balances.json
+++ b/data/balances/crowdsale_c699d9_eth_balances.json
@@ -1,0 +1,64 @@
+{
+  "contract": "0xc699d90671cb8373f21060592d41a7c92280adc4",
+  "balance_source": "eth",
+  "contract_eth_balance": 2.4175959,
+  "total_eth_in_balances": 2.3175959,
+  "addresses_with_balance": 6,
+  "coverage_pct": 95.86,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed ICO (same softcap-miss design as Mahala): balance < softcap after endIco opens refund(), returning each contributor their own balances[] deposit. The owner payout needs softcap reached (never), so the stuck ETH is refund-only.",
+  "distribution": {
+    "0.1-1 ETH": {
+      "count": 6,
+      "total_eth": 2.3175959
+    }
+  },
+  "name": "Crowdsale (0xc699d9)",
+  "claim_flow": "refund()",
+  "refund_selector": "0x590e1ae3",
+  "balance_selector": "0x27e235e3",
+  "state_checks": [
+    "this.balance < softcap && now > endIco"
+  ],
+  "total_addresses_scanned": 7,
+  "residual_unattributed_eth": 0.1,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0xa46e3aac59412b0e1458badeabd1061254ecefa6",
+      "balance_wei": "979000000000000000",
+      "balance_eth": 0.979
+    },
+    {
+      "rank": 2,
+      "address": "0x16ae442cb793ca94c1b1764beb7a1a5e4e0dbf19",
+      "balance_wei": "410000000000000000",
+      "balance_eth": 0.41
+    },
+    {
+      "rank": 3,
+      "address": "0x68bb8089fbf5bfc17495721070a2716e582e620b",
+      "balance_wei": "300000000000000000",
+      "balance_eth": 0.3
+    },
+    {
+      "rank": 4,
+      "address": "0x59269d50b9769d37f8464b11ac739cee2074bf4c",
+      "balance_wei": "254897900000000000",
+      "balance_eth": 0.2548979
+    },
+    {
+      "rank": 5,
+      "address": "0x922f5ba9782da5c94669b942babc7918e8d891cd",
+      "balance_wei": "201402445000000000",
+      "balance_eth": 0.20140245
+    },
+    {
+      "rank": 6,
+      "address": "0xe5e3e51977bdc9c2a9a2836430ff4eddf4a41cd3",
+      "balance_wei": "172295556821709923",
+      "balance_eth": 0.17229556
+    }
+  ]
+}

--- a/data/balances/crowdsale_e82056_eth_balances.json
+++ b/data/balances/crowdsale_e82056_eth_balances.json
@@ -1,0 +1,91 @@
+{
+  "contract": "0xe8205644fef286a2af423b72669e662feec127cd",
+  "balance_source": "eth",
+  "contract_eth_balance": 2.41,
+  "total_eth_in_balances": 2.21,
+  "addresses_with_balance": 9,
+  "coverage_pct": 91.7,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A classic failed-ICO refund crowdsale past deadline with the funding goal unmet, so safeWithdrawal() (!goalReached branch) returns each contributor their own balanceOf[] deposit. The beneficiary payout needs the goal reached (never), so the owner cannot drain.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 1.0
+    },
+    "0.1-1 ETH": {
+      "count": 7,
+      "total_eth": 1.16
+    },
+    "0.01-0.1 ETH": {
+      "count": 1,
+      "total_eth": 0.05
+    }
+  },
+  "name": "Crowdsale (0xe82056)",
+  "claim_flow": "safeWithdrawal()",
+  "refund_selector": "0xfd6b7ef8",
+  "balance_selector": "0x70a08231",
+  "state_checks": [
+    "now >= deadline()",
+    "fundingGoal not reached"
+  ],
+  "total_addresses_scanned": 10,
+  "residual_unattributed_eth": 0.2,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x9be60578ef64b9b53db049c8d33855dc94be3cd7",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 2,
+      "address": "0xc7b43d6a94c388fca9259a2943428980f7661631",
+      "balance_wei": "500000000000000000",
+      "balance_eth": 0.5
+    },
+    {
+      "rank": 3,
+      "address": "0x2db3c22da3ce43dc3314f24295c1d57f78d3616c",
+      "balance_wei": "160000000000000000",
+      "balance_eth": 0.16
+    },
+    {
+      "rank": 4,
+      "address": "0x33b80ea8f35537453af7a3b0943d11f02e27b58d",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 5,
+      "address": "0xaae1cb04c830fa907210355c0dcea3118b445bb0",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 6,
+      "address": "0x95f50e94a3bcc47e8613cf095b148146b15c6376",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 7,
+      "address": "0x9fc90e89f2700f529668c6ebed53a6a3d426b5be",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 8,
+      "address": "0xbc8bc0904fd2864d5b52025bc51005422f2f53c3",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 9,
+      "address": "0x3d7b0e4404de2a8cef04c4f9a62746914242b7b4",
+      "balance_wei": "50000000000000000",
+      "balance_eth": 0.05
+    }
+  ]
+}

--- a/data/balances/crowdsalewatch_eth_balances.json
+++ b/data/balances/crowdsalewatch_eth_balances.json
@@ -1,0 +1,34 @@
+{
+  "contract": "0x6f303642844f734ad4176d0dfe93ef7e0776ef46",
+  "balance_source": "eth",
+  "contract_eth_balance": 2.0,
+  "total_eth_in_balances": 2.0,
+  "addresses_with_balance": 1,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "An OpenZeppelin-template crowdsale (CrowdsaleWatch) where amountRaised (2.000 ETH) never reached fundingGoal, so the !fundingGoalReached branch of safeWithdrawal() returns each contributor their own balanceOf[] deposit. The owner payout branch is unreachable, so the stuck ETH is refund-only.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 2.0
+    }
+  },
+  "name": "CrowdsaleWatch",
+  "claim_flow": "safeWithdrawal()",
+  "refund_selector": "0xfd6b7ef8",
+  "balance_selector": "0x70a08231",
+  "state_checks": [
+    "amountRaised() < fundingGoal() (deadline passed)"
+  ],
+  "total_addresses_scanned": 1,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x287e2c76aab4720786076c3deedd7dd386092050",
+      "balance_wei": "2000000000000000000",
+      "balance_eth": 2.0
+    }
+  ]
+}

--- a/data/balances/gateway_ico_3091d3_eth_balances.json
+++ b/data/balances/gateway_ico_3091d3_eth_balances.json
@@ -1,0 +1,88 @@
+{
+  "contract": "0x3091d37ef18cb33af72cf7ca63714733172ce724",
+  "balance_source": "eth",
+  "contract_eth_balance": 1.41257813,
+  "total_eth_in_balances": 1.40079855,
+  "addresses_with_balance": 8,
+  "coverage_pct": 99.17,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed ICO (Gateway) whose refund() returns each contributor their own balances[] deposit. The owner ETH-out is gated by the unreached goal, so the owner cannot drain the stuck ETH.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 1.0
+    },
+    "0.1-1 ETH": {
+      "count": 3,
+      "total_eth": 0.32892482
+    },
+    "0.01-0.1 ETH": {
+      "count": 3,
+      "total_eth": 0.06246174
+    },
+    "<0.01 ETH": {
+      "count": 1,
+      "total_eth": 0.009412
+    }
+  },
+  "name": "Gateway ICO (0x3091d3)",
+  "claim_flow": "refund()",
+  "refund_selector": "0x590e1ae3",
+  "balance_selector": "0x27e235e3",
+  "state_checks": [
+    "failed-ICO refund gate (balance < goal after end)"
+  ],
+  "total_addresses_scanned": 8,
+  "residual_unattributed_eth": 0.01177958,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x3856d3d5ec20486193dd4efe6e74d9e67e4d5cc5",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 2,
+      "address": "0x5d618eb3807d7cacaeaf68627bd22c60c3c87ca5",
+      "balance_wei": "114482785340101523",
+      "balance_eth": 0.11448279
+    },
+    {
+      "rank": 3,
+      "address": "0xd89d5c6850f6b1abdeae90496373199586b0c89e",
+      "balance_wei": "113754079119000000",
+      "balance_eth": 0.11375408
+    },
+    {
+      "rank": 4,
+      "address": "0xa924e9df267343f47354b37e55b386403c169013",
+      "balance_wei": "100687950567527921",
+      "balance_eth": 0.10068795
+    },
+    {
+      "rank": 5,
+      "address": "0xdc9ea6c7a3245cf7294a06280b8e46bb4dc1f5e2",
+      "balance_wei": "32614022000000000",
+      "balance_eth": 0.03261402
+    },
+    {
+      "rank": 6,
+      "address": "0xc26afae9b3b93d5806c4b3ec6aa16b9283c7caec",
+      "balance_wei": "19847715736040610",
+      "balance_eth": 0.01984772
+    },
+    {
+      "rank": 7,
+      "address": "0x46f51bb1ec957baeb4a7bee244e697c2124d7fcf",
+      "balance_wei": "10000000000000000",
+      "balance_eth": 0.01
+    },
+    {
+      "rank": 8,
+      "address": "0xc051c98a0aed9f1257c02cb53f57a46f3dbf69c3",
+      "balance_wei": "9411999999999998",
+      "balance_eth": 0.009412
+    }
+  ]
+}

--- a/data/balances/i2presale_eth_balances.json
+++ b/data/balances/i2presale_eth_balances.json
@@ -1,0 +1,91 @@
+{
+  "contract": "0xa8df33a40fe2e3278e4d94a974f70778043fbd20",
+  "balance_source": "eth",
+  "contract_eth_balance": 5.795,
+  "total_eth_in_balances": 5.795,
+  "addresses_with_balance": 9,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A 2018 presale (I2Presale, solc 0.4.20) past its deadline (1521417823, Mar-2018) with the funding goal unmet, so the afterDeadline + goal-not-reached gate opens safeWithdrawal(), which returns each contributor their own balanceOf[] deposit. The beneficiary path requires the goal reached (never), so the owner cannot drain.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 3,
+      "total_eth": 4.46
+    },
+    "0.1-1 ETH": {
+      "count": 4,
+      "total_eth": 1.263
+    },
+    "0.01-0.1 ETH": {
+      "count": 2,
+      "total_eth": 0.072
+    }
+  },
+  "name": "I2 Presale",
+  "claim_flow": "safeWithdrawal()",
+  "refund_selector": "0xfd6b7ef8",
+  "balance_selector": "0x70a08231",
+  "state_checks": [
+    "now >= deadline()",
+    "fundingGoal not reached"
+  ],
+  "total_addresses_scanned": 9,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x90b3cd92f207f7a118f3e4a3ebfab248656a27de",
+      "balance_wei": "2000000000000000000",
+      "balance_eth": 2.0
+    },
+    {
+      "rank": 2,
+      "address": "0xd5b1480f142020b409eb4808af5b2fc274354119",
+      "balance_wei": "1460000000000000000",
+      "balance_eth": 1.46
+    },
+    {
+      "rank": 3,
+      "address": "0x563805c2056dd0f8daf5719a8222d935098e1848",
+      "balance_wei": "1000000000000000000",
+      "balance_eth": 1.0
+    },
+    {
+      "rank": 4,
+      "address": "0x34f79d3072348f993ddd1dabfc1cf2b7baadd9cd",
+      "balance_wei": "421000000000000000",
+      "balance_eth": 0.421
+    },
+    {
+      "rank": 5,
+      "address": "0x979f58ec7f80eaa8ec85fea90b36bc09247442e6",
+      "balance_wei": "400000000000000000",
+      "balance_eth": 0.4
+    },
+    {
+      "rank": 6,
+      "address": "0x9cb6247bf9e22da514b1b32acae28c560c73d848",
+      "balance_wei": "300000000000000000",
+      "balance_eth": 0.3
+    },
+    {
+      "rank": 7,
+      "address": "0x46799e47592928ea6d8b30497eead7dcf7e6b2e6",
+      "balance_wei": "142000000000000000",
+      "balance_eth": 0.142
+    },
+    {
+      "rank": 8,
+      "address": "0xe60a9ab929514848d5100a67677beba09b9e0da7",
+      "balance_wei": "60000000000000000",
+      "balance_eth": 0.06
+    },
+    {
+      "rank": 9,
+      "address": "0x24676a678723c49ed3390ba315220027b1805ade",
+      "balance_wei": "12000000000000000",
+      "balance_eth": 0.012
+    }
+  ]
+}

--- a/data/balances/mahala_coin_ico_eth_balances.json
+++ b/data/balances/mahala_coin_ico_eth_balances.json
@@ -1,0 +1,70 @@
+{
+  "contract": "0xe117bb9d1e0fc6e859d9bf174c53baa7c673547a",
+  "balance_source": "eth",
+  "contract_eth_balance": 2.94837577,
+  "total_eth_in_balances": 2.94837577,
+  "addresses_with_balance": 7,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed MHC ICO whose balance (2.948 ETH) is below softcap after endIco, satisfying the refund() gate require(this.balance < softcap && now > endIco). refund() returns each contributor their own balances[] deposit. The owner withdraw path needs softcap reached, so the owner cannot drain.",
+  "distribution": {
+    "0.1-1 ETH": {
+      "count": 7,
+      "total_eth": 2.94837577
+    }
+  },
+  "name": "Mahala Coin (MHC) Crowdsale",
+  "claim_flow": "refund()",
+  "refund_selector": "0x590e1ae3",
+  "balance_selector": "0x27e235e3",
+  "state_checks": [
+    "this.balance < softcap && now > endIco"
+  ],
+  "total_addresses_scanned": 7,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x228720286945e354e22b8a79214c553c2287eb29",
+      "balance_wei": "900000000000000000",
+      "balance_eth": 0.9
+    },
+    {
+      "rank": 2,
+      "address": "0x6e97121a734b90f5814e1b4934430b834eba8d3e",
+      "balance_wei": "620000000000000000",
+      "balance_eth": 0.62
+    },
+    {
+      "rank": 3,
+      "address": "0x9007cd824d9566ee1147edce25185b79672fe711",
+      "balance_wei": "500000000000000000",
+      "balance_eth": 0.5
+    },
+    {
+      "rank": 4,
+      "address": "0x68bb8089fbf5bfc17495721070a2716e582e620b",
+      "balance_wei": "400000000000000000",
+      "balance_eth": 0.4
+    },
+    {
+      "rank": 5,
+      "address": "0x2aa6d50364108023e70385545729005469b9a906",
+      "balance_wei": "233301637000000000",
+      "balance_eth": 0.23330164
+    },
+    {
+      "rank": 6,
+      "address": "0x790b8fba18ffd22310457fb9f3af644a480333f6",
+      "balance_wei": "195074130000000000",
+      "balance_eth": 0.19507413
+    },
+    {
+      "rank": 7,
+      "address": "0xa46e3aac59412b0e1458badeabd1061254ecefa6",
+      "balance_wei": "100000000000000000",
+      "balance_eth": 0.1
+    }
+  ]
+}

--- a/data/balances/reservation2_eth_balances.json
+++ b/data/balances/reservation2_eth_balances.json
@@ -1,0 +1,34 @@
+{
+  "contract": "0xde0b79f5e66fdc8a4ffb2c470756a1629e8ad569",
+  "balance_source": "eth",
+  "contract_eth_balance": 1.9,
+  "total_eth_in_balances": 1.9,
+  "addresses_with_balance": 1,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "An Aug-2017 ICO reservation contract with no state gate: withdraw() simply returns each depositor their own balanceOf[] deposit. Immutable refund of own principal; not front-runnable (pays msg.sender their own ledger entry).",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 1.9
+    }
+  },
+  "name": "Reservation2",
+  "claim_flow": "withdraw()",
+  "refund_selector": "0x3ccfd60b",
+  "balance_selector": "0x70a08231",
+  "state_checks": [
+    "balanceOf[msg.sender] > 0 (no additional gate)"
+  ],
+  "total_addresses_scanned": 1,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x43fc2e15836706799d96f4d857088b950624a4c9",
+      "balance_wei": "1900000000000000000",
+      "balance_eth": 1.9
+    }
+  ]
+}

--- a/data/balances/singulardtv_launch_eth_balances.json
+++ b/data/balances/singulardtv_launch_eth_balances.json
@@ -1,0 +1,45 @@
+{
+  "contract": "0x6feaf4e8f386c08b4518c175874b332329d0d6ba",
+  "balance_source": "eth",
+  "contract_eth_balance": 1.0206,
+  "total_eth_in_balances": 1.0206,
+  "addresses_with_balance": 2,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "The 2018 SingularDTV token-creation sale (ConsenSys) reached only 810 of a 1,000-token target, so the timedTransitions modifier auto-advances stage to EndedAndGoalNotReached, opening withdrawContribution(). A contributor first approves the launch contract for their sentTokens, then withdrawContribution() pulls those tokens back and returns their own contributions[] ETH. withdrawForWorkshop() needs the (unreachable) goal-reached stage, so the owner cannot drain. (Distinct contract from the SingularDTVFund dividend pools.)",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 1.008
+    },
+    "0.01-0.1 ETH": {
+      "count": 1,
+      "total_eth": 0.0126
+    }
+  },
+  "name": "SingularDTV Launch (ConsenSys)",
+  "claim_flow": "approve(token, launch) then withdrawContribution()",
+  "refund_selector": "0x0d616d20",
+  "balance_selector": "0x42e94c90",
+  "state_checks": [
+    "updateStage() == 2 (EndedAndGoalNotReached)",
+    "approve(launch, sentTokens) prerequisite"
+  ],
+  "total_addresses_scanned": 2,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0xf09151d8dd5dcbf4f8bf47edf54af2d2e60c5865",
+      "balance_wei": "1008000000000000000",
+      "balance_eth": 1.008
+    },
+    {
+      "rank": 2,
+      "address": "0xd7b4cbac3cb90f5ad46f632f7991cd58a0a13aa4",
+      "balance_wei": "12600000000000000",
+      "balance_eth": 0.0126
+    }
+  ]
+}

--- a/data/balances/startmining_stm_sale_eth_balances.json
+++ b/data/balances/startmining_stm_sale_eth_balances.json
@@ -1,0 +1,132 @@
+{
+  "contract": "0xe8da050c3140183d4f5f01e048ac136e2da5253f",
+  "balance_source": "eth",
+  "contract_eth_balance": 5.98113793,
+  "total_eth_in_balances": 5.98113793,
+  "addresses_with_balance": 16,
+  "coverage_pct": 100.0,
+  "scan_date": "2026-06-11 00:00:00 UTC",
+  "description": "A failed STM token sale: minting was finished one-way (getFinishStatus()==true) without reaching the token goal, opening manualRefund(), which returns each investor their own recorded ETH (getInvestorsETH(address)). The owner payout path is gated by canMint / the unreached goal and reverts, so the stuck ETH is refund-only.",
+  "distribution": {
+    "1-10 ETH": {
+      "count": 1,
+      "total_eth": 3.02
+    },
+    "0.1-1 ETH": {
+      "count": 6,
+      "total_eth": 2.21575862
+    },
+    "0.01-0.1 ETH": {
+      "count": 9,
+      "total_eth": 0.74537931
+    }
+  },
+  "name": "Start Mining (STM) Token Sale",
+  "claim_flow": "manualRefund()",
+  "refund_selector": "0x14c7bddf",
+  "balance_selector": "0x0c8a611f",
+  "state_checks": [
+    "getFinishStatus() == true (minting finished, token goal unmet)"
+  ],
+  "total_addresses_scanned": 16,
+  "residual_unattributed_eth": 0.0,
+  "residual_note": "Excess over the sum of self-claimable EOA ledgers is held by contract / exchange-deposit addresses that are not simple self-claimable owners; excluded from the holder list above.",
+  "balances": [
+    {
+      "rank": 1,
+      "address": "0x7cd3ebe1e2e11f8cfdd07326bc700d52ee5aee89",
+      "balance_wei": "3019999999999969800",
+      "balance_eth": 3.02
+    },
+    {
+      "rank": 2,
+      "address": "0x15f715811025b9dfccba1690b519f11aed12997a",
+      "balance_wei": "684482758620676650",
+      "balance_eth": 0.68448276
+    },
+    {
+      "rank": 3,
+      "address": "0x5fada93672a20671cef6e8b839f0869fbd397ad7",
+      "balance_wei": "548275862068955100",
+      "balance_eth": 0.54827586
+    },
+    {
+      "rank": 4,
+      "address": "0x7dbcad020bcacd012605ef282082c1404e2b29b0",
+      "balance_wei": "399999999999992400",
+      "balance_eth": 0.4
+    },
+    {
+      "rank": 5,
+      "address": "0x56fb84e7c768dfed90ce5012be7a8a84edf6674a",
+      "balance_wei": "202999999999996143",
+      "balance_eth": 0.203
+    },
+    {
+      "rank": 6,
+      "address": "0xfda82d198990cabdeb0743feb75023b1071b3ff7",
+      "balance_wei": "199999999999996200",
+      "balance_eth": 0.2
+    },
+    {
+      "rank": 7,
+      "address": "0xd641c1edd60534a3743daad6f795a00dc4802b08",
+      "balance_wei": "179999999999998200",
+      "balance_eth": 0.18
+    },
+    {
+      "rank": 8,
+      "address": "0x3c6211a64508c45f5cd9fee363610d9dcb6000ed",
+      "balance_wei": "99999999999999000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 9,
+      "address": "0x273e8d3411fbba5be32b20b1fa975607888f5dcb",
+      "balance_wei": "99999999999999000",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 10,
+      "address": "0xbdf9b5bda53c709cce44a073067b3e26afe1d816",
+      "balance_wei": "99999999999998100",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 11,
+      "address": "0xfb9f01f2f8c0d920b88e7d3c171a569a6e07a9f5",
+      "balance_wei": "99999999999998100",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 12,
+      "address": "0xc5de97de45cf59eaa97d89c68fac549167b85d28",
+      "balance_wei": "99999999999998100",
+      "balance_eth": 0.1
+    },
+    {
+      "rank": 13,
+      "address": "0x3471bb1a8a0442332a19156e610f1a8f5cfde4b0",
+      "balance_wei": "90379310344825869",
+      "balance_eth": 0.09037931
+    },
+    {
+      "rank": 14,
+      "address": "0x0a481a67cb605cdc9e58b489e296d55ad841eb18",
+      "balance_wei": "59999999999998860",
+      "balance_eth": 0.06
+    },
+    {
+      "rank": 15,
+      "address": "0x9f383498fe44e838a1ac537b0f13047ac54f91a3",
+      "balance_wei": "49999999999999050",
+      "balance_eth": 0.05
+    },
+    {
+      "rank": 16,
+      "address": "0x252c9a3d88da5f70905a161a4c85e1b417e808a7",
+      "balance_wei": "44999999999999550",
+      "balance_eth": 0.045
+    }
+  ]
+}

--- a/data/protocols.json
+++ b/data/protocols.json
@@ -2182,5 +2182,110 @@
     "category": "ico",
     "balance_file": "ztcrowdsale_eth_balances.json",
     "multi_step": true
+  },
+  {
+    "key": "abyss_daico_fund",
+    "name": "Abyss DAICO Fund (PollManagedFund)",
+    "contract": "0xe4972421f88c1f47986f54cbfd2d1e2e671680ac",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "abyss_daico_fund_eth_balances.json"
+  },
+  {
+    "key": "confideal_campaign",
+    "name": "Confideal Campaign",
+    "contract": "0x17681500757628c7aa56d7e6546e119f94dd9479",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "confideal_campaign_eth_balances.json"
+  },
+  {
+    "key": "crowdsale_4363b5",
+    "name": "Crowdsale (0x4363b5)",
+    "contract": "0x4363b5d64f228c819dc706889b09a0dc76e22fb0",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "crowdsale_4363b5_eth_balances.json"
+  },
+  {
+    "key": "startmining_stm_sale",
+    "name": "Start Mining (STM) Token Sale",
+    "contract": "0xe8da050c3140183d4f5f01e048ac136e2da5253f",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "startmining_stm_sale_eth_balances.json"
+  },
+  {
+    "key": "i2presale",
+    "name": "I2 Presale",
+    "contract": "0xa8df33a40fe2e3278e4d94a974f70778043fbd20",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "i2presale_eth_balances.json"
+  },
+  {
+    "key": "bayesin_bys_crowsale",
+    "name": "Bayesin (BYS) CrowSale",
+    "contract": "0xe8b1b40f2d307bce891833f46eef1f69560e6926",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "bayesin_bys_crowsale_eth_balances.json"
+  },
+  {
+    "key": "mahala_coin_ico",
+    "name": "Mahala Coin (MHC) Crowdsale",
+    "contract": "0xe117bb9d1e0fc6e859d9bf174c53baa7c673547a",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "mahala_coin_ico_eth_balances.json"
+  },
+  {
+    "key": "crowdsale_c699d9",
+    "name": "Crowdsale (0xc699d9)",
+    "contract": "0xc699d90671cb8373f21060592d41a7c92280adc4",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "crowdsale_c699d9_eth_balances.json"
+  },
+  {
+    "key": "crowdsale_e82056",
+    "name": "Crowdsale (0xe82056)",
+    "contract": "0xe8205644fef286a2af423b72669e662feec127cd",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "crowdsale_e82056_eth_balances.json"
+  },
+  {
+    "key": "crowdsalewatch",
+    "name": "CrowdsaleWatch",
+    "contract": "0x6f303642844f734ad4176d0dfe93ef7e0776ef46",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "crowdsalewatch_eth_balances.json"
+  },
+  {
+    "key": "reservation2",
+    "name": "Reservation2",
+    "contract": "0xde0b79f5e66fdc8a4ffb2c470756a1629e8ad569",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "reservation2_eth_balances.json"
+  },
+  {
+    "key": "gateway_ico_3091d3",
+    "name": "Gateway ICO (0x3091d3)",
+    "contract": "0x3091d37ef18cb33af72cf7ca63714733172ce724",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "gateway_ico_3091d3_eth_balances.json"
+  },
+  {
+    "key": "singulardtv_launch",
+    "name": "SingularDTV Launch (ConsenSys)",
+    "contract": "0x6feaf4e8f386c08b4518c175874b332329d0d6ba",
+    "balance_source": "eth",
+    "category": "ico",
+    "balance_file": "singulardtv_launch_eth_balances.json",
+    "multi_step": true
   }
 ]


### PR DESCRIPTION
## Add 13 fork-verified failed-ICO refund vaults (~57 ETH, 87 self-claimable addresses)

A second batch of stuck-ETH refund vaults, found by extending the same free-BigQuery discovery sweep that produced the earlier failed-ICO refund set — this time mining the **1–10 ETH band** (the first pass only looked above 10 ETH). All are the same **open-refund** shape already in the registry: a failed/aborted token sale where each contributor's own ETH sits in a per-account ledger and an **intended** refund function pays `msg.sender` back exactly their own deposit. No exploit, no custody — the rightful contributor signs.

### How each was verified (the fork is the sole oracle)
1. **Discovery** — BigQuery `balances ⨝ contracts` (1–10 ETH, created < 2019-07), minus the existing registry and our already-contributed set → verified-legacy source only → an AST detector for the self-paying-refund shape. 1,147 verified-legacy candidates → 41 open-refund survivors.
2. **Adversarial triage** — every survivor independently classified and then attacked by two refuters (funds-provenance/solvency + liveness/false-positive/owner-trap). 41 → 14 confirmed; the 27 drops were NFT marketplaces, gambling games, dividend/escrow pools, flattened-source sibling matches, owner-drainable sales, and gate-unsatisfiable ICOs.
3. **Fork-proof** — a bespoke Foundry **mainnet-fork** test per target proving a **real unclaimed contributor reclaims exactly their own deposit**, that a second call cannot pay again (idempotence), that a non-contributor gets nothing (LOW-tier, not front-runnable), and that the **owner cannot drain** the pool. **39/39 tests green** across the 13 targets. (1 of the 14 was dropped here — the owner could drain it — leaving 13.)
4. **Holder lists** — enumerated on-chain, reconciled to the live balance, filtered to **self-claimable EOAs**: contract addresses and exchange/service hot wallets are excluded (Binance + a service wallet were caught by the nonce screen).

### Targets

| Protocol | Contract | ETH | Addrs | Refund flow | Why open / why owner can't drain |
|---|---|---:|---:|---|---|
| Abyss DAICO Fund | `0xe497…80ac` | 9.90 | 13 | `refundCrowdsaleContributor()` | `state()==1 CrowdsaleRefund` latched; team paths need unreachable states |
| Confideal Campaign | `0x1768…9479` | 8.20 | 4 | `withdrawRefund()` | `stage()==3 Failure` (9.6 ETH vs 1000 ETH threshold) |
| Crowdsale | `0x4363…2fb0` | 8.28 | 6 | `releaseEthers()` | saleFailed: past end & below softCap |
| Start Mining (STM) | `0xe8da…253f` | 5.98 | 16 | `manualRefund()` | minting finished one-way, token goal unmet |
| I2 Presale | `0xa8df…bd20` | 5.80 | 9 | `safeWithdrawal()` | past deadline, goal not reached |
| Bayesin (BYS) | `0xe8b1…6926` | 5.43 | 5 | `safeWithdrawal()` | past deadline, max goal unmet |
| Mahala Coin (MHC) | `0xe117…547a` | 2.95 | 7 | `refund()` | balance < softcap after endIco |
| Crowdsale | `0xc699…adc4` | 2.32 | 6 | `refund()` | balance < softcap after endIco |
| Crowdsale | `0xe820…27cd` | 2.21 | 9 | `safeWithdrawal()` | past deadline, goal not reached |
| CrowdsaleWatch | `0x6f30…ef46` | 2.00 | 1 | `safeWithdrawal()` | amountRaised < fundingGoal |
| Reservation2 | `0xde0b…d569` | 1.90 | 1 | `withdraw()` | own-deposit ledger, no extra gate |
| Gateway ICO | `0x3091…e724` | 1.40 | 8 | `refund()` | failed-ICO gate satisfied |
| SingularDTV Launch | `0x6fea…d6ba` | 1.02 | 2 | `approve` → `withdrawContribution()` | `updateStage()==2 EndedAndGoalNotReached` |

**Total: ~57.4 ETH, 87 self-claimable addresses.**

### Notes
- Files follow the current enriched balance schema (`balance_source: "eth"`, ranked `balances`, `distribution`, `claim_flow`, `refund_selector`/`balance_selector`, `state_checks`, `residual_unattributed_eth`). `residual_unattributed_eth` is the slice held by excluded contract/exchange addresses.
- **Abyss** contributors paid the crowdsale (which forwarded to the Fund), so holders were enumerated from the token's mint events and reconcile to the wei (13 unrefunded == balance; 269 already refunded).
- **SingularDTV Launch** refund is a two owner-signed steps (approve the launch contract for the contributor's tokens, then `withdrawContribution()`); both steps are reproduced in the fork-proof.
- I left `data/index_shards`, `data/table_meta`, and `data/total.json` for your pipeline. Happy to adjust keys/categories/format to your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
